### PR TITLE
Criação de modais da tela de clientes

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -20,6 +20,7 @@
         "electron-updater": "^6.1.7",
         "react-hook-form": "^7.54.0",
         "react-icons": "^5.3.0",
+        "react-input-mask": "^2.0.4",
         "react-router-dom": "^7.0.1",
         "styled-components": "^6.1.13",
         "zod": "^3.24.0"
@@ -7651,6 +7652,19 @@
         "react": "*"
       }
     },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9316,6 +9330,14 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/front/package.json
+++ b/front/package.json
@@ -32,6 +32,7 @@
     "electron-updater": "^6.1.7",
     "react-hook-form": "^7.54.0",
     "react-icons": "^5.3.0",
+    "react-input-mask": "^2.0.4",
     "react-router-dom": "^7.0.1",
     "styled-components": "^6.1.13",
     "zod": "^3.24.0"

--- a/front/src/renderer/src/views/components/Fab/index.tsx
+++ b/front/src/renderer/src/views/components/Fab/index.tsx
@@ -1,13 +1,34 @@
 import { LuPlus } from 'react-icons/lu';
+import InputMask from 'react-input-mask';
 
 import { DropdownMenu } from '../DropdownMenu';
 
 import { BusinessIcon } from '@renderer/assets/Icons/Business';
 import { ClientIcon } from '@renderer/assets/Icons/ClientIcon';
+import { Input } from '@renderer/views/components/Input';
 
-import { Container, StyledButton, StyledItem } from './styles';
+import { Container, StyledButton, StyledItem, FormModal } from './styles';
+
+import Modal from '../Modal';
+
+import { useFabController } from './useFabController';
 
 export default function Fab() {
+
+  const {
+    isOpenModalClient,
+    isOpenModalCompany,
+    handleOpenClientModal,
+    handleOpenCompanyModal,
+    handleCloseClientModal,
+    handleCloseCompanyModal,
+    handleClientSubmit,
+    handleSubmit,
+    register,
+    errors,
+  }  = useFabController();
+
+
   return (
     <Container>
       <DropdownMenu.Root>
@@ -18,13 +39,13 @@ export default function Fab() {
       </DropdownMenu.Trigger>
 
         <DropdownMenu.Content side='top' sideOffset={4} align='end'>
-          <DropdownMenu.Item onSelected={() => console.log('funcoinou')} asChild>
+          <DropdownMenu.Item onSelected={() => handleOpenClientModal()} asChild>
             <StyledItem>
               <ClientIcon />
               Novo cliente
             </StyledItem>
           </DropdownMenu.Item>
-          <DropdownMenu.Item onSelected={() => console.log('funcoinou')} asChild>
+          <DropdownMenu.Item onSelected={() => handleOpenCompanyModal()} asChild>
             <StyledItem>
               <BusinessIcon />
               Nova empresa
@@ -32,6 +53,107 @@ export default function Fab() {
           </DropdownMenu.Item>
         </DropdownMenu.Content>
     </DropdownMenu.Root>
+
+    <Modal
+      open={isOpenModalClient}
+      onClose={handleCloseClientModal}
+      title='Novo cliente'
+      action={<button className="saveClient" onClick={() => console.log("salvando cliente")} type='submit' form='client-form'>Adicionar Cliente</button>}
+      children={
+        <FormModal id='client-form'
+          onSubmit={ handleSubmit(handleClientSubmit) }
+        >
+          <Input
+            type="text"
+            placeholder="Nome do cliente"
+            $error={errors.name?.message}
+            {...register('name')}
+          />
+
+          <InputMask
+            mask='(99) 99999-9999'
+            maskChar={null}
+            {...register('phone')}>
+            {(inputProps: any) => <Input type="text" placeholder='Telefone do cliente' {...inputProps} />}
+          </InputMask>
+          <Input
+            type="text"
+            placeholder='Endereço do cliente'
+            {...register('address')}
+           />
+           <InputMask
+            mask='999.999.999-99'
+            maskChar={null}
+            {...register('cpf')}>
+            {(inputProps: any) => <Input type="text" placeholder='CPF do cliente' {...inputProps} />}
+            </InputMask>
+
+          <div className='dividerInput'>
+            <Input
+              type="number"
+              placeholder='Numero'
+              {...register('number')}
+            />
+            <Input
+              type="text"
+              placeholder='Bairro'
+              {...register('district')}
+            />
+          </div>
+        </FormModal>
+      }
+      />
+
+<Modal
+      open={isOpenModalCompany}
+      onClose={handleCloseCompanyModal}
+      title='Nova Empresa'
+      action={<button className="saveClient" onClick={() => console.log("salvando cliente")} type='submit' form='company-form'>Adicionar Cliente</button>}
+      children={
+        <FormModal id='company-form' onSubmit={ handleSubmit(handleClientSubmit) }>
+          <Input
+            type="text"
+            placeholder="Nome da empresa"
+            $error={errors.name?.message}
+            {...register('name')}
+          />
+
+          <InputMask
+            mask='(99) 99999-9999'
+            maskChar={null}
+            {...register('phone')}
+           >
+            {(inputProps: any) => <Input type="text" placeholder='Telefone da empresa' {...inputProps} />}
+           </InputMask>
+          <Input
+            type="text"
+            placeholder='Endereço da empresa'
+            {...register('address')}
+           />
+
+           <InputMask
+            mask='99.999.999/9999-99'
+            maskChar={null}
+            {...register('cnpj')}
+           >
+            {(inputProps: any) => <Input type="text" placeholder='CNPJ da empresa' {...inputProps} />}
+           </InputMask>
+
+          <div className='dividerInput'>
+            <Input
+              type="number"
+              placeholder='Numero'
+              {...register('number')}
+            />
+            <Input
+              type="text"
+              placeholder='Bairro'
+              {...register('district')}
+            />
+          </div>
+        </FormModal>
+      }
+      />
     </Container>
   );
 }

--- a/front/src/renderer/src/views/components/Fab/styles.ts
+++ b/front/src/renderer/src/views/components/Fab/styles.ts
@@ -17,13 +17,53 @@ export const StyledButton = styled.button`
   padding: 1.2rem;
   width: 4.8rem;
   border: none;
+  transition: background .3s;
 
   &[data-state="open"] {
     transform: rotate(90deg);
+  }
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.green.dark};
+    transition: background .3s;
   }
 `;
 
 export const StyledItem = styled.button`
   width: 100%;
   gap: .8rem;
+  transition: background .3s;
+  
+  &:hover {
+    transition: background .3s;
+  }
+`;
+
+export const FormModal = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  .dividerInput {
+    display: flex;
+    /* gap: 10px; */
+    justify-content: space-between;
+    width: 100%;
+    gap: 1.2rem;
+    align-items: center;
+    margin-top: 1.2rem;
+
+    & > div {
+      margin-top: 0;
+    }
+
+    & > div:first-child {
+      width: 45%;
+    }
+
+    & > div:last-child {
+      width: 100%;
+    }
+  }
 `;

--- a/front/src/renderer/src/views/components/Fab/useFabController.ts
+++ b/front/src/renderer/src/views/components/Fab/useFabController.ts
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+const clientFormSchema = z.object({
+  name: z.string().min(1, "O nome do cliente é um campo obrigatório"),
+  phone: z.string().optional(),
+  address: z.string().optional(),
+  number: z.string().optional(),
+  district: z.string().optional(),
+  cpf: z.string().optional(),
+  cnpj: z.string().optional(),
+});
+
+type ClientForm = {
+  name: string;
+  phone?: string;
+  address?: string;
+  number?: string;
+  district?: string;
+  cpf?: string;
+  cnpj?: string;
+};
+
+export const useFabController = () => {
+  const [isOpenModalClient, setOpenModalClient] = useState(false);
+  const [isOpenModalCompany, setOpenModalCompany] = useState(false);
+
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<ClientForm>({
+    resolver: zodResolver(clientFormSchema),
+  });
+
+  const handleOpenClientModal = () => {
+    reset();
+    setOpenModalClient(true);
+  };
+
+  const handleOpenCompanyModal = () => {
+    reset();
+    setOpenModalCompany(true);
+  };
+
+  const handleCloseClientModal = () => {
+    setOpenModalClient(false);
+  };
+
+  const handleCloseCompanyModal = () => {
+    setOpenModalCompany(false);
+  };
+
+  const handleClientSubmit = (data: ClientForm) => {
+    console.log(data);
+    reset();
+    setOpenModalClient(false);
+  };
+
+  return {
+    isOpenModalClient,
+    isOpenModalCompany,
+    handleOpenClientModal,
+    handleOpenCompanyModal,
+    handleCloseClientModal,
+    handleCloseCompanyModal,
+    handleClientSubmit,
+    handleSubmit,
+    register,
+    errors,
+  };
+};

--- a/front/src/renderer/src/views/components/Modal/index.tsx
+++ b/front/src/renderer/src/views/components/Modal/index.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 
-import { CloseIcon } from '@renderer/assets/Icons/CloseIcon';
-import { ActionContainer, CloseButton, Header, StyledRdxDialogContent, StyledRdxDialogOverlay, Title } from './styles';
+// import { CloseIcon } from '@renderer/assets/Icons/CloseIcon';
+import { ActionContainer, CloseButton, Header, StyledRdxDialogContent, StyledRdxDialogOverlay, Title, Footer } from './styles';
 interface ModalProps {
   open: boolean;
   children: React.ReactNode;
@@ -18,18 +18,21 @@ export default function Modal({ title, action, open, children, onClose }: ModalP
 			<StyledRdxDialogContent aria-describedby=''>
         <Dialog.Title about={title}>
           <Header>
-            <CloseButton onClick={onClose}>
-              <CloseIcon />
-            </CloseButton>
-
             <Title>{title}</Title>
-
-            <ActionContainer>
-              {action}
-            </ActionContainer>
           </Header>
         </Dialog.Title>
+
 				{children}
+        <Footer>
+          <CloseButton onClick={onClose}>
+            {/* <CloseIcon /> */}
+            <span>Cancelar</span>
+          </CloseButton>
+        
+          <ActionContainer>
+            {action}
+          </ActionContainer>
+        </Footer>
 			</StyledRdxDialogContent>
 		</Dialog.Portal>
 	</Dialog.Root>

--- a/front/src/renderer/src/views/components/Modal/styles.ts
+++ b/front/src/renderer/src/views/components/Modal/styles.ts
@@ -21,7 +21,8 @@ const contentShow = keyframes`
 	}
 `;
 
-export const StyledRdxDialogContent = styled(Dialog.Content)`
+export const 
+StyledRdxDialogContent = styled(Dialog.Content)`
   animation: ${contentShow} 0.3s forwards;
   background: #FFF;
   border-radius: ${({ theme }) => theme.borderRadius};
@@ -57,13 +58,13 @@ export const StyledRdxDialogOverlay = styled(Dialog.Overlay)`
 export const Header = styled.header`
   align-items: center;
   display: flex;
-  justify-content: space-between;
+  justify-content: center; //mudança
   width: 100%;
   margin-bottom: 3.2rem;
 `;
 
-export const CloseButton = styled.button`
-  background: transparent;
+export const CloseButton = styled.span` //button -> span
+  /* background: red;
   border: none;
   border-radius: 50%;
   display: flex;
@@ -71,7 +72,20 @@ export const CloseButton = styled.button`
   height: 48px;
   padding: 12px;
   justify-content: center;
-  align-items: center;
+  align-items: center; */
+  cursor: pointer;
+
+  /* span { */
+    font-size: 16px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.colors.gray.main};
+    transition: color .3s;
+
+    &:hover {
+      color: ${({ theme }) => theme.colors.gray.light};
+      transition: color .3s;
+    }
+  /* } */
 `;
 
 export const Title = styled.h1`
@@ -80,7 +94,30 @@ export const Title = styled.h1`
   font-weight: 500;
 `;
 
+export const Footer = styled.footer`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 24px;
+`;
+
 export const ActionContainer = styled.div`
-  width: 4.8rem;
-  height: 4.8rem;
+  /* width: 4.8rem;
+  height: 4.8rem; */
+
+  button.saveClient {
+    background-color: ${({ theme }) => theme.colors.orange.light};
+    color: #FFF;
+    border-radius: 10px;
+    padding: 14px;
+    border: none;
+    font-weight: 600;
+    font-size: 16px;
+    transition: background .3s;
+
+    &:hover {
+      background-color: ${({ theme }) => theme.colors.orange.dark};
+      transition: background .3s;
+    }
+  }
 `;


### PR DESCRIPTION
**Criação de modais da tela de clientes**
_O que foi feito:_ foram criados dois modais que servirão para adicionar clientes físicos e clientes jurídicos à coleção de clientes do estabelecimento. Além disso, foram realizadas estilizações no botão de adicionar (que apresenta o ícone '+'), para ajudar na usabilidade do usuário.
_Implementação:_  os modais foram feitos usando o componente já existente no sistema, feito usando a biblioteca "radix ui", também foi adicionada estilização própria ao formulário e validação de obrigatoriedade para o campo "Nome" usando Zod e aplicação de máscaras aos campos de "Telefone", "CPF" e "CNPJ", usando o React Input Mask.